### PR TITLE
Use nice Error messages

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -71,6 +71,26 @@ export const errors = {
 };
 
 /**
+ * Like Error, but with a property set to true.
+ *
+ * Example: instead of:
+ *     const err = new Error("input is not a buffer");
+ *     err.badTypeInput = true;
+ *     throw err;
+ * use:
+ *     throw new PropError("badTypeInput", "input is not a buffer");
+ *
+ * @param {String} propName - the property name.
+ * @param {String} message - the Error message.
+ */
+class PropError extends Error {
+    constructor(propName, message) {
+        super(message);
+        this[propName] = true;
+    }
+}
+
+/**
  * Gets the key of an object with its value.
  * @param {Object} object - the corresponding object.
  * @param {String} value - the corresponding value.
@@ -138,11 +158,8 @@ export class PDU extends stream.Readable {
         this._chunk = undefined;
 
         if (input !== undefined) {
-            if (!Buffer.isBuffer(input)) {
-                const err = new Error("input is not a buffer");
-                err.badTypeInput = true;
-                throw err;
-            }
+            if (!Buffer.isBuffer(input))
+                throw new PropError("badTypeInput", "input is not a buffer");
             this._parse(input);
         }
         return this;
@@ -347,25 +364,18 @@ export class PDU extends stream.Readable {
      * @returns {number} - an error code
      */
     _parse(data) {
-        if (data.length < 9) {
-            const err = new Error("PDU message is truncated");
-            err.badLength = true;
-            throw err;
-        }
+        if (data.length < 9)
+            throw new PropError("badLength", "PDU message is truncated");
 
         const version = data.readInt8(0);
         const pbMsgLen = data.readInt32BE(1);
         const chunkLen = data.readInt32BE(5);
 
-        if (version !== getVersion()) {
-            const err = new Error('version failure');
-            err.badVersion = true;
-            throw err;
-        } else if (data.length !== 9 + pbMsgLen + chunkLen) {
-            const err = new Error("PDU message is truncated or too long");
-            err.badLength = true;
-            throw err;
-        }
+        if (version !== getVersion())
+            throw new PropError("badVersion", "version failure");
+        else if (data.length !== 9 + pbMsgLen + chunkLen)
+            throw new PropError("badLength",
+                                "PDU message is truncated or too long");
 
         try {
             this._cmd = protoBuild.Message.decode(data.slice(9, 9 + pbMsgLen));
@@ -380,11 +390,8 @@ export class PDU extends stream.Readable {
         this.setChunk(data.slice(pbMsgLen + 9, chunkLen + pbMsgLen + 9));
 
         if (this._cmd.authType === 1 &&
-                !this.hmacIntegrity(this.getSlice(this._cmd.hmacAuth.hmac))) {
-            const err = new Error('HMAC does not match');
-            err.hmacFail = true;
-            throw err;
-        }
+                !this.hmacIntegrity(this.getSlice(this._cmd.hmacAuth.hmac)))
+            throw new PropError("hmacFail", "HMAC does not match");
     }
 }
 


### PR DESCRIPTION
Define a new class `PropError` that inherits from `Error`, so we can create
errors with properties in one line. This allows code simplification, for
instance, when we used to write:

``` js
const err = new Error("input is not a buffer");
err.badTypeInput = true;
throw err;
```

Now we can write:

``` js
throw new PropError("badTypeInput", "input is not a buffer");
```
