### PR TITLE
PDU: Accept strings for key and errorMessage arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const chunk = new Buffer("D4T4d4t4D4T4d4t4D4T4d4t4D4T4d4t4D4T4d4t4");
 const pdu = new kinetic.PutPDU(
     1,                                   // sequence number
     1989,                                // clusterVersion
-    new Buffer("mykey"),                 // key
+    "mykey",                             // key
     chunk.length,                        // chunkSize
     new Buffer('44'), new Buffer('45')   // dbVersion, newVersion
 );

--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -462,6 +462,22 @@ export function streamToPDU(s, callback) {
     });
 }
 
+function validateBufferArgument(arg) {
+    if (Buffer.isBuffer(arg))
+        return arg;
+
+    throw propError("badArg", "argument is not a buffer");
+}
+
+function validateBufferOrStringArgument(arg) {
+    if (Buffer.isBuffer(arg))
+        return arg;
+    else if (typeof arg === "string")
+        return new Buffer(arg);
+
+    throw propError("badArg", "argument is neither a buffer nor a string");
+}
+
 /**
  * Getting logs and stats request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
@@ -473,6 +489,7 @@ export function streamToPDU(s, callback) {
 export class GetLogPDU extends PDU {
     constructor(sequence, clusterVersion, types) {
         super();
+
         const connectionID = (new Date).getTime();
         this.setMessage({
             "header": {
@@ -501,10 +518,11 @@ export class GetLogPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetLogResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage, responseLogs) {
+    constructor(ackSequence, response, errorMessageArg, responseLogs) {
         super();
-        if (!Buffer.isBuffer(errorMessage))
-            throw new Error("the error message is not a buffer");
+
+        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+
         this.setMessage({
             "header": {
                 "ackSequence": ackSequence,
@@ -532,6 +550,7 @@ export class GetLogResponsePDU extends PDU {
 export class FlushPDU extends PDU {
     constructor(sequence, clusterVersion) {
         super();
+
         const connectionID = (new Date).getTime();
         this.setMessage({
             "header": {
@@ -556,10 +575,11 @@ export class FlushPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class FlushResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage) {
+    constructor(ackSequence, response, errorMessageArg) {
         super();
-        if (!Buffer.isBuffer(errorMessage))
-            throw new Error("the error message is not a buffer");
+
+        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+
         this.setMessage({
             "header": {
                 "messageType": "FLUSHALLDATA_RESPONSE",
@@ -587,6 +607,7 @@ export class FlushResponsePDU extends PDU {
 export class SetClusterVersionPDU extends PDU {
     constructor(sequence, clusterVersion, oldClusterVersion) {
         super();
+
         const connectionID = (new Date).getTime();
         this.setMessage({
             "header": {
@@ -614,10 +635,11 @@ export class SetClusterVersionPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class SetupResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage) {
+    constructor(ackSequence, response, errorMessageArg) {
         super();
-        if (!Buffer.isBuffer(errorMessage))
-            throw new Error("the error message is not a buffer");
+
+        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+
         this.setMessage({
             "header": {
                 "messageType": "SETUP_RESPONSE",
@@ -643,6 +665,7 @@ export class SetupResponsePDU extends PDU {
 export class NoOpPDU extends PDU {
     constructor(sequence, clusterVersion) {
         super();
+
         const connectionID = (new Date).getTime();
         this.setMessage({
             "header": {
@@ -667,10 +690,11 @@ export class NoOpPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class NoOpResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage) {
+    constructor(ackSequence, response, errorMessageArg) {
         super();
-        if (!Buffer.isBuffer(errorMessage))
-            throw new Error("the error message is not a buffer");
+
+        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+
         this.setMessage({
             "header": {
                 "messageType": "NOOP_RESPONSE",
@@ -698,15 +722,13 @@ export class NoOpResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class PutPDU extends PDU {
-    constructor(sequence, clusterVersion, key, chunkSize,
-                dbVersion, newVersion) {
+    constructor(sequence, clusterVersion, keyArg, chunkSize,
+                dbVersionArg, newVersionArg) {
         super();
-        if (!Buffer.isBuffer(key))
-            throw new Error("key is not a buffer");
-        if (!Buffer.isBuffer(dbVersion))
-            throw new Error("old dbversion is not a buffer");
-        if (!Buffer.isBuffer(newVersion))
-            throw new Error("new dbversion is not a buffer");
+
+        const key = validateBufferOrStringArgument(keyArg);
+        const dbVersion = validateBufferArgument(dbVersionArg);
+        const newVersion = validateBufferArgument(newVersionArg);
 
         const connectionID = (new Date).getTime();
         this._chunkSize = chunkSize;
@@ -739,10 +761,11 @@ export class PutPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class PutResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage) {
+    constructor(ackSequence, response, errorMessageArg) {
         super();
-        if (!Buffer.isBuffer(errorMessage))
-            throw new Error("the error message is not a buffer");
+
+        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+
         this.setMessage({
             "header": {
                 "messageType": "PUT_RESPONSE",
@@ -770,10 +793,11 @@ export class PutResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetPDU extends PDU {
-    constructor(sequence, clusterVersion, key) {
+    constructor(sequence, clusterVersion, keyArg) {
         super();
-        if (!Buffer.isBuffer(key))
-            throw new Error("key is not a buffer");
+
+        const key = validateBufferOrStringArgument(keyArg);
+
         const connectionID = (new Date).getTime();
         this.setMessage({
             "header": {
@@ -804,13 +828,13 @@ export class GetPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage, key,
-                chunkSize, dbVersion) {
+    constructor(ackSequence, response, errorMessageArg, keyArg,
+                chunkSize, dbVersionArg) {
         super();
-        if (!Buffer.isBuffer(errorMessage))
-            throw new Error("the error message is not a buffer");
-        if (!Buffer.isBuffer(dbVersion))
-            throw new Error("dbVersion is not a buffer");
+
+        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const key = validateBufferOrStringArgument(keyArg);
+        const dbVersion = validateBufferArgument(dbVersionArg);
 
         this._chunkSize = chunkSize;
         this.setMessage({
@@ -844,12 +868,12 @@ export class GetResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class DeletePDU extends PDU {
-    constructor(sequence, clusterVersion, key, dbVersion) {
+    constructor(sequence, clusterVersion, keyArg, dbVersionArg) {
         super();
-        if (!Buffer.isBuffer(key))
-            throw new Error("key is not a buffer");
-        if (!Buffer.isBuffer(dbVersion))
-            throw new Error("dbVersion is not a buffer");
+
+        const key = validateBufferOrStringArgument(keyArg);
+        const dbVersion = validateBufferArgument(dbVersionArg);
+
         const connectionID = (new Date).getTime();
         this.setMessage({
             "header": {

--- a/tests/unit/kinetic.js
+++ b/tests/unit/kinetic.js
@@ -715,79 +715,119 @@ describe('kinetic.PDU encoding()', () => {
 });
 
 describe('kinetic.PutPDU()', () => {
-    it('should check key type', (done) => {
+    it('should accept string key', (done) => {
         try {
             const k = new kinetic.PutPDU(
                 1, 1, "string", 12, new Buffer('2'), new Buffer('3'));
             k;
-            done(new Error("constructor accepted string-typed key"));
-        } catch (e) {
-            if (e.message !== "key is not a buffer")
-                done(e);
             done();
+        } catch (e) {
+            done(e);
         }
     });
-    it('should check the old dbVersion type', (done) => {
+
+    it('should not accept non-string non-buffer key', (done) => {
         try {
             const k = new kinetic.PutPDU(
-                1, 1, new Buffer("string"), 12, '2', new Buffer('3'));
+                1, 1, 77777, 12, new Buffer('2'), new Buffer('3'));
+            k;
+            done(new Error("constructor accepted invalid key type"));
+        } catch (e) {
+            if (e.badArg)
+                done();
+            else
+                done(e);
+        }
+    });
+
+    it('should not accept non-buffer dbVersion', (done) => {
+        try {
+            const k = new kinetic.PutPDU(
+                1, 1, "string", 12, '2', new Buffer('3'));
             k;
             done(new Error("constructor accepted string-typed key"));
         } catch (e) {
-            if (e.message !== "old dbversion is not a buffer")
+            if (e.badArg)
+                done();
+            else
                 done(e);
-            done();
         }
     });
-    it('should check the new dbVersion type', (done) => {
+
+    it('should not accept non-buffer newVersion', (done) => {
         try {
             const k = new kinetic.PutPDU(
-                1, 1, new Buffer("string"), 12, new Buffer('2'), '3');
+                1, 1, "string", 12, new Buffer('2'), '3');
             k;
             done(new Error("constructor accepted string-typed key"));
         } catch (e) {
-            if (e.message !== "new dbversion is not a buffer")
+            if (e.badArg)
+                done();
+            else
                 done(e);
-            done();
         }
     });
 });
 
 describe('kinetic.GetPDU()', () => {
-    it('should check key type', (done) => {
+    it('should accept string key', (done) => {
         try {
-            const k = new kinetic.GetPDU( 1, 2, "string");
+            const k = new kinetic.GetPDU(1, 2, "string");
+            k;
+            done();
+        } catch (e) {
+            done(e);
+        }
+    });
+
+    it('should not accept non-string non-buffer key', (done) => {
+        try {
+            const k = new kinetic.GetPDU(1, 2, 7777777);
             k;
             done(new Error("constructor accepted string-typed key"));
         } catch (e) {
-            if (e.message !== "key is not a buffer")
+            if (e.badArg)
+                done();
+            else
                 done(e);
-            done();
         }
     });
 });
 
 describe('kinetic.DeletePDU()', () => {
-    it('should check key type', (done) => {
+    it('should accept string key', (done) => {
         try {
-            const k = new kinetic.DeletePDU( 1, 2, "string", new Buffer('3'));
+            const k = new kinetic.DeletePDU(1, 2, "string", new Buffer('3'));
             k;
-            done(new Error("constructor accepted string-typed key"));
-        } catch (e) {
-            if (e.message !== "key is not a buffer")
-                done(e);
             done();
+        } catch (e) {
+            done(e);
         }
     });
-    it('should check the dbVersion type', (done) => {
+
+    it('should not accept non-string non-buffer key', (done) => {
         try {
-            const k = new kinetic.DeletePDU( 1, 2, new Buffer("string"), '3');
+            const k = new kinetic.DeletePDU(1, 2, 777777, new Buffer('3'));
             k;
             done(new Error("constructor accepted string-typed key"));
         } catch (e) {
-            if (e.message !== "dbVersion is not a buffer")
+            if (e.badArg)
+                done();
+            else
                 done(e);
-            done();
+        }
+    });
+
+    it('should not accept non-buffer dbVersion', (done) => {
+        try {
+            const k = new kinetic.DeletePDU(1, 2, "string", '3');
+            k;
+            done(new Error("constructor accepted string-typed key"));
+        } catch (e) {
+            if (e.badArg)
+                done();
+            else
+                done(e);
         }
     });
 });


### PR DESCRIPTION
#### Note: This pull request is based on pull request #14, only the last commit is important

It's convenient to be able to use strings for chunk keys and for error messages. It also saves space in client code and avoid visual pollution.

This patch allows this and adapts tests accordingly.
