### PR TITLE
REFACTOR: Use optional args in kinetic constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,22 @@ import net from 'net';
 import kinetic from 'kineticlib';
 
 const chunk = new Buffer("D4T4d4t4D4T4d4t4D4T4d4t4D4T4d4t4D4T4d4t4");
+const options = {
+    dbVersion: new Buffer('44'),        // The actual version of the value in
+                                        // the database
+    newVersion: new Buffer('45'),       // The updated version of the value in
+                                        // the database
+    force: false                        // Setting force to true ignores
+                                        // potential version mismatches and
+                                        // carries out the operation.
+    clusterVersion                      // the cluster version
+}
+
 const pdu = new kinetic.PutPDU(
     1,                                   // sequence number
-    1989,                                // clusterVersion
     "mykey",                             // key
     chunk.length,                        // chunkSize
-    new Buffer('44'), new Buffer('45')   // dbVersion, newVersion
+    options,                             // options
 );
 
 const sock = net.connect(1234, 'localhost');

--- a/TESTING.md
+++ b/TESTING.md
@@ -14,8 +14,7 @@ Sure. You can run some tests locally:
 
 ```
 npm run --silent lint
-npm run --silent tests_unit
-npm run --silent tests_functional
+npm run --silent test
 ```
 
 Integration and performance tests really need a CI infrastructure to simulate
@@ -41,10 +40,10 @@ import kinetic from '../index.js';
 
 let rawData = undefined;
 
-const k = new kinetic.NoOpPDU(123, 9876798);
+const k = new kinetic.NoOpPDU(123);
 
 
-// if you want a put, you need a chunk : 
+// if you want a put or a get response, you need a chunk : 
 // k.setChunk(new Buffer("HI EVERYBODY"));
 
 
@@ -123,48 +122,3 @@ requestsArr.forEach(writeHex);
      - GET
      - DELETE
    
-## Functional tests
-
-Functional tests are located in the `tests/functional` directory.
-
-### Architecture
-
-* Kinetic Device simulator `tests/dependencies`
-  - TCP connection
-  - JAVA simulator
-  - maven is needed for the build
-    - Download : https://maven.apache.org/download.cgi
-    - Installation guide : https://maven.apache.org/install.html
-* mocha
-
-### Method
-
-Test are run by:
-* lauching the Makefile located in the tests/functional directory :
-  - make submodule_sync
-    - sync and load the dependencies (simulator package) 
-  - make build_cache
-    - build the simulator package with cache rule for avoiding many downloads 
-      and builds
-  - make start_simulator
-    - start the simulator
-  - make stop_simulator
-    - stop the simulator
-  - make run_test
-    - run the tests with mocha (`tests/functional/simulTest.js`)
-  - can use make for an automatic load
-
-### Functions tested
-
-* Kinetic
-  - Build (kinetic compatibility)
-    - Protobuf message
-    - Buffer sent format
-  - Parse
-    - Decode the received buffer
-    - Check Version
-    - HmacIntegrity 
-      (compute an HMAC from the PDU and compare it to the one sent)
-  - Send()
-    - Check the simulator returns (SUCCESS)
-    - The simulator check the HMAC(integrity of PDU sent)

--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -501,25 +501,30 @@ function validateBufferOrStringArgument(arg) {
  * Getting logs and stats request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection.
- * @param {number} clusterVersion - version of the cluster
- * @param {Array} types - array filled by logs types needed.
+ * @param {Object} options - optional :
+ *                  {number} [options.clusterVersion = 0] - the cluster version
+ *                  {Array} [options.types = [0, 1, 2, 4, 5, 6]] - logs types
+ *                  needed
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetLogPDU extends PDU {
-    constructor(sequence, clusterVersion, types) {
+    constructor(sequence, options = {}) {
         super();
 
         const connectionID = (new Date).getTime();
+
         this.setMessage({
             "header": {
                 "messageType": "GETLOG",
                 "connectionID": connectionID,
                 "sequence": sequence,
-                "clusterVersion": clusterVersion,
+                "clusterVersion": Number.isInteger(options.clusterVersion) ?
+                    options.clusterVersion : 0,
             },
             "body": {
                 "getLog": {
-                    "types": types,
+                    "types": Array.isArray(options.types) ?
+                        options.types : [0, 1, 2, 4, 5, 6],
                 },
             },
         });
@@ -563,11 +568,12 @@ export class GetLogResponsePDU extends PDU {
  * Flush all data request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection.
- * @param {number} clusterVersion - version of the cluster
+ * @param {Object} options - optional :
+ *                  {number} [options.clusterVersion = 0] - the cluster version
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class FlushPDU extends PDU {
-    constructor(sequence, clusterVersion) {
+    constructor(sequence, options = {}) {
         super();
 
         const connectionID = (new Date).getTime();
@@ -576,7 +582,8 @@ export class FlushPDU extends PDU {
                 "messageType": "FLUSHALLDATA",
                 "connectionID": connectionID,
                 "sequence": sequence,
-                "clusterVersion": clusterVersion,
+                "clusterVersion": Number.isInteger(options.clusterVersion) ?
+                    options.clusterVersion : 0,
             },
             "body": {
             },
@@ -677,12 +684,12 @@ export class SetupResponsePDU extends PDU {
  * NOOP request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection
- * @param {number} clusterVersion - The version number of this cluster
- *                                  definition
+ * @param {Object} options - optional :
+ *                  {number} [options.clusterVersion = 0] - the cluster version
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class NoOpPDU extends PDU {
-    constructor(sequence, clusterVersion) {
+    constructor(sequence, options = {}) {
         super();
 
         const connectionID = (new Date).getTime();
@@ -691,7 +698,8 @@ export class NoOpPDU extends PDU {
                 "messageType": "NOOP",
                 "connectionID": connectionID,
                 "sequence": sequence,
-                "clusterVersion": clusterVersion,
+                "clusterVersion": Number.isInteger(options.clusterVersion) ?
+                    options.clusterVersion : 0,
             },
             "body": {
             },
@@ -732,23 +740,32 @@ export class NoOpResponsePDU extends PDU {
  * PUT request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection
- * @param {number} clusterVersion - The version number of this cluster
- *                                  definition
  * @param {Buffer} key - key of the item to put.
  * @param {number} chunkSize - size of the chunk to put.
  * @param {Buffer} dbVersion - version of the item in the database.
  * @param {Buffer} newVersion - new version of the item to put.
- * @param {boolean} force - the force value.
+ * @param {Object} options - optional :
+ *                  {String} [options.synchronization = WRITETHROUGH] - to
+ *                  specify if the data must be written to disk immediately,
+ *                  or can be written in the future.
+ *                  {number} [options.clusterVersion = 0] - the cluster version
+ *                  {boolean} [options.force = null] - optional setting force to
+ *                  true ignores potential version mismatches and carries out
+ *                  the operation.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class PutPDU extends PDU {
-    constructor(sequence, clusterVersion, keyArg, chunkSize,
-                dbVersionArg, newVersionArg, force) {
+    constructor(sequence, keyArg, chunkSize, options = {}) {
         super();
 
+        let dbVersion = null;
+        let newVersion = null;
+
         const key = validateBufferOrStringArgument(keyArg);
-        const dbVersion = validateBufferArgument(dbVersionArg, true);
-        const newVersion = validateBufferArgument(newVersionArg);
+        if (options.dbVersion)
+            dbVersion = validateBufferArgument(options.dbVersion);
+        if (options.newVersion)
+            newVersion = validateBufferArgument(options.newVersion);
 
         const connectionID = (new Date).getTime();
         this._chunkSize = chunkSize;
@@ -757,15 +774,18 @@ export class PutPDU extends PDU {
                 "messageType": "PUT",
                 "connectionID": connectionID,
                 "sequence": sequence,
-                "clusterVersion": clusterVersion,
+                "clusterVersion": Number.isInteger(options.clusterVersion) ?
+                    options.clusterVersion : 0,
             },
             "body": {
                 "keyValue": {
                     "key": key,
                     "newVersion": newVersion,
                     "dbVersion": dbVersion,
-                    "force": force,
-                    "synchronization": 'WRITETHROUGH',
+                    "synchronization": options.synchronization ||
+                        'WRITETHROUGH',
+                    "force": typeof options.force === 'boolean' ?
+                             options.force : null,
                 },
             },
         });
@@ -811,13 +831,15 @@ export class PutResponsePDU extends PDU {
  * @param {number} clusterVersion - The version number of this cluster
  *                                  definition
  * @param {Buffer} key - key of the item to get.
- * @param {boolean} [options.metadataOnly = false] -
- *                  If true, only metadata (not the full value) will be returned
- *                  If false, metadata and value will be returned
+ * @param {Object} options - optional :
+ *                  {Boolean} [options.metadataOnly = false] - If true, only
+ *                  metadata (not the full value) will be returned,
+ *                  If false, metadata and value will be returned.
+ *                  {number} [options.clusterVersion = 0] - the cluster version
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetPDU extends PDU {
-    constructor(sequence, clusterVersion, keyArg, metadata) {
+    constructor(sequence, keyArg, options = {}) {
         super();
         const key = validateBufferOrStringArgument(keyArg);
 
@@ -827,13 +849,14 @@ export class GetPDU extends PDU {
                 "messageType": "GET",
                 "connectionID": connectionID,
                 "sequence": sequence,
-                "clusterVersion": clusterVersion,
+                "clusterVersion": Number.isInteger(options.clusterVersion) ?
+                    options.clusterVersion : 0,
             },
             "body": {
                 "keyValue": {
                     "key": key,
-                    "metadataOnly": typeof metadata === 'boolean' ?
-                                    metadata : null,
+                    "metadataOnly": typeof options.metadataOnly === 'boolean' ?
+                                    options.metadataOnly : null,
                 },
             },
         });
@@ -890,15 +913,25 @@ export class GetResponsePDU extends PDU {
  *                                  definition
  * @param {Buffer} key - key of the item to delete.
  * @param {Buffer} dbVersion - version of the item in the database.
- * @param {boolean} force - the force value.
+ * @param {Object} options - optional :
+ *                  {String} [options.synchronization = 'WRITETHROUGH'] -
+ *                  to specify if the data must be written to disk immediately,
+ *                  or can be written in the future.
+ *                  {number} [options.clusterVersion = 0] - the cluster version
+ *                  {boolean} [options.force = null] - optional setting force to
+ *                  true ignores potential version mismatches and carries out
+ *                  the operation.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class DeletePDU extends PDU {
-    constructor(sequence, clusterVersion, keyArg, dbVersionArg, force) {
+    constructor(sequence, keyArg, options = {}) {
         super();
 
+        let dbVersion = null;
+
         const key = validateBufferOrStringArgument(keyArg);
-        const dbVersion = validateBufferArgument(dbVersionArg, true);
+        if (options.dbVersion)
+            dbVersion = validateBufferArgument(options.dbVersion);
 
         const connectionID = (new Date).getTime();
         this.setMessage({
@@ -906,14 +939,17 @@ export class DeletePDU extends PDU {
                 "messageType": "DELETE",
                 "connectionID": connectionID,
                 "sequence": sequence,
-                "clusterVersion": clusterVersion,
+                "clusterVersion": Number.isInteger(options.clusterVersion) ?
+                    options.clusterVersion : 0,
             },
             "body": {
                 "keyValue": {
                     "key": key,
                     "dbVersion": dbVersion,
-                    "force": force,
-                    "synchronization": 'WRITETHROUGH',
+                    "synchronization": options.synchronization ||
+                        'WRITETHROUGH',
+                    "force": typeof options.force === 'boolean' ?
+                             options.force : null,
                 },
             },
         });


### PR DESCRIPTION
NOT for direct merge. Please comment !!!
- Implement options object parameter for more flexible function
  - clusterVersion, getLog types, synchronization
  - set a default value for cluster version to 0:
    https://github.com/Kinetic/kinetic-protocol#cross-cutting-concerns
  - set a default value for synchronization to 'WRITETHOUGH':
    https://github.com/Kinetic/kinetic-protocol#modify-value-operations
  - no optional in requests response(maybe errorMessage or detailMessage)
    https://github.com/Kinetic/kinetic-protocol#cross-cutting-concerns
  - Add the force field
  - update relatives unit tests
