### PR TITLE
PDU: Fix missing `getForce` method

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -323,6 +323,14 @@ export class PDU extends stream.Readable {
     }
 
     /**
+     * Gets the force value of the data unit.
+     * @returns {boolean} - Whether force is true or false.
+     */
+    getForce() {
+        return this._message.body.keyValue.force;
+    }
+
+    /**
      * Gets the detailed error message.
      * @returns {Buffer} - Detailed error message.
      */
@@ -470,8 +478,11 @@ export function streamToPDU(s, callback) {
     });
 }
 
-function validateBufferArgument(arg) {
+function validateBufferArgument(arg, allowUndefined = false) {
     if (Buffer.isBuffer(arg))
+        return arg;
+
+    if (allowUndefined && arg === undefined)
         return arg;
 
     throw propError("badArg", "argument is not a buffer");
@@ -727,15 +738,16 @@ export class NoOpResponsePDU extends PDU {
  * @param {number} chunkSize - size of the chunk to put.
  * @param {Buffer} dbVersion - version of the item in the database.
  * @param {Buffer} newVersion - new version of the item to put.
+ * @param {boolean} force - the force value.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class PutPDU extends PDU {
     constructor(sequence, clusterVersion, keyArg, chunkSize,
-                dbVersionArg, newVersionArg) {
+                dbVersionArg, newVersionArg, force) {
         super();
 
         const key = validateBufferOrStringArgument(keyArg);
-        const dbVersion = validateBufferArgument(dbVersionArg);
+        const dbVersion = validateBufferArgument(dbVersionArg, true);
         const newVersion = validateBufferArgument(newVersionArg);
 
         const connectionID = (new Date).getTime();
@@ -752,6 +764,7 @@ export class PutPDU extends PDU {
                     "key": key,
                     "newVersion": newVersion,
                     "dbVersion": dbVersion,
+                    "force": force,
                     "synchronization": 'WRITETHROUGH',
                 },
             },
@@ -798,13 +811,16 @@ export class PutResponsePDU extends PDU {
  * @param {number} clusterVersion - The version number of this cluster
  *                                  definition
  * @param {Buffer} key - key of the item to get.
+ * @param {Buffer} dbVersion - version of the item in the database.
+ * @param {boolean} force - the force value.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetPDU extends PDU {
-    constructor(sequence, clusterVersion, keyArg) {
+    constructor(sequence, clusterVersion, keyArg, dbVersionArg, force) {
         super();
 
         const key = validateBufferOrStringArgument(keyArg);
+        const dbVersion = validateBufferArgument(dbVersionArg, true);
 
         const connectionID = (new Date).getTime();
         this.setMessage({
@@ -817,6 +833,8 @@ export class GetPDU extends PDU {
             "body": {
                 "keyValue": {
                     "key": key,
+                    "dbVersion": dbVersion,
+                    "force": force
                 },
             },
         });
@@ -873,14 +891,15 @@ export class GetResponsePDU extends PDU {
  *                                  definition
  * @param {Buffer} key - key of the item to delete.
  * @param {Buffer} dbVersion - version of the item in the database.
+ * @param {boolean} force - the force value.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class DeletePDU extends PDU {
-    constructor(sequence, clusterVersion, keyArg, dbVersionArg) {
+    constructor(sequence, clusterVersion, keyArg, dbVersionArg, force) {
         super();
 
         const key = validateBufferOrStringArgument(keyArg);
-        const dbVersion = validateBufferArgument(dbVersionArg);
+        const dbVersion = validateBufferArgument(dbVersionArg, true);
 
         const connectionID = (new Date).getTime();
         this.setMessage({
@@ -894,6 +913,7 @@ export class DeletePDU extends PDU {
                 "keyValue": {
                     "key": key,
                     "dbVersion": dbVersion,
+                    "force": force,
                     "synchronization": 'WRITETHROUGH',
                 },
             },


### PR DESCRIPTION
Clients need to be able to check the value of the `force` field for PUT, GET and
DELETE messages. This patch adds a function to retrieve this value from PDUs.
