### PR TITLE
CLEANUP(kinetic) - Clean and unify lib code 

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -516,8 +516,8 @@ export class GetLogPDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "GETLOG",
-                connectionID: connectionID,
-                sequence: sequence,
+                connectionID,
+                sequence,
                 clusterVersion: Number.isInteger(options.clusterVersion) ?
                     options.clusterVersion : 0,
             },
@@ -536,28 +536,28 @@ export class GetLogPDU extends PDU {
  * Getting logs and stats response following the kinetic protocol.
  * @param {number} ackSequence - monotically increasing number for each request
  *                               in a TCP connection
- * @param {number} response - response code (SUCCESS, FAIL)
- * @param {Buffer} errorMessage - detailed error message.
- * @param {object} responseLogs - object filled by logs needed.
+ * @param {number} code - response code (SUCCESS, FAIL)
+ * @param {Buffer} errorMessageArg - detailed error message.
+ * @param {object} getLog - object filled by logs needed.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetLogResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessageArg, responseLogs) {
+    constructor(ackSequence, code, errorMessageArg, getLog) {
         super();
 
-        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
 
         this.setMessage({
             header: {
-                ackSequence: ackSequence,
+                ackSequence,
                 messageType: "GETLOG_RESPONSE",
             },
             body: {
-                getLog: responseLogs,
+                getLog,
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;
@@ -581,8 +581,8 @@ export class FlushPDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "FLUSHALLDATA",
-                connectionID: connectionID,
-                sequence: sequence,
+                connectionID,
+                sequence,
                 clusterVersion: Number.isInteger(options.clusterVersion) ?
                     options.clusterVersion : 0,
             },
@@ -597,24 +597,24 @@ export class FlushPDU extends PDU {
  * Flush all data response following the kinetic protocol.
  * @param {number} ackSequence - monotically increasing number for each request
  *                               in a TCP connection
- * @param {number} response - response code (SUCCESS, FAIL)
- * @param {Buffer} errorMessage - detailed error message.
+ * @param {number} code - response code (SUCCESS, FAIL)
+ * @param {Buffer} errorMessageArg - detailed error message.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class FlushResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessageArg) {
+    constructor(ackSequence, code, errorMessageArg) {
         super();
 
-        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
 
         this.setMessage({
             header: {
                 messageType: "FLUSHALLDATA_RESPONSE",
-                ackSequence: ackSequence,
+                ackSequence,
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;
@@ -625,14 +625,14 @@ export class FlushResponsePDU extends PDU {
  * set clusterVersion request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection.
- * @param {number} clusterVersion - The version number of this cluster
+ * @param {number} newClusterVersion - The version number of this cluster
  *                                  definition
- * @param {number} oldClusterVersion - The old version number of this cluster
+ * @param {number} clusterVersion - The old version number of this cluster
  *                                     definition
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class SetClusterVersionPDU extends PDU {
-    constructor(sequence, clusterVersion, oldClusterVersion) {
+    constructor(sequence, newClusterVersion, clusterVersion) {
         super();
 
         const connectionID = (new Date).getTime();
@@ -640,13 +640,13 @@ export class SetClusterVersionPDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "SETUP",
-                connectionID: connectionID,
-                sequence: sequence,
-                clusterVersion: oldClusterVersion,
+                connectionID,
+                sequence,
+                clusterVersion,
             },
             body: {
                 setup: {
-                    newClusterVersion: clusterVersion,
+                    newClusterVersion,
                 },
             },
         });
@@ -658,24 +658,24 @@ export class SetClusterVersionPDU extends PDU {
  * Setup response request following the kinetic protocol.
  * @param {number} ackSequence - monotically increasing number for each request
  *                               in a TCP connection
- * @param {number} response - response code (SUCCESS, FAIL)
- * @param {Buffer} errorMessage - detailed error message.
+ * @param {number} code - response code (SUCCESS, FAIL)
+ * @param {Buffer} errorMessageArg - detailed error message.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class SetupResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessageArg) {
+    constructor(ackSequence, code, errorMessageArg) {
         super();
 
-        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
 
         this.setMessage({
             header: {
                 messageType: "SETUP_RESPONSE",
-                ackSequence: ackSequence,
+                ackSequence,
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;
@@ -699,8 +699,8 @@ export class NoOpPDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "NOOP",
-                connectionID: connectionID,
-                sequence: sequence,
+                connectionID,
+                sequence,
                 clusterVersion: Number.isInteger(options.clusterVersion) ?
                     options.clusterVersion : 0,
             },
@@ -715,24 +715,24 @@ export class NoOpPDU extends PDU {
  * Response for the NOOP request following the kinetic protocol.
  * @param {number} ackSequence - monotically increasing number for each request
  *                               in a TCP connection
- * @param {number} response - response code (SUCCESS, FAIL)
- * @param {Buffer} errorMessage - detailed error message.
+ * @param {number} code - response code (SUCCESS, FAIL)
+ * @param {Buffer} errorMessageArg - detailed error message.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class NoOpResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessageArg) {
+    constructor(ackSequence, code, errorMessageArg) {
         super();
 
-        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
 
         this.setMessage({
             header: {
                 messageType: "NOOP_RESPONSE",
-                ackSequence: ackSequence,
+                ackSequence,
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;
@@ -775,16 +775,16 @@ export class PutPDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "PUT",
-                connectionID: connectionID,
-                sequence: sequence,
+                connectionID,
+                sequence,
                 clusterVersion: Number.isInteger(options.clusterVersion) ?
                     options.clusterVersion : 0,
             },
             body: {
                 keyValue: {
-                    key: key,
-                    newVersion: newVersion,
-                    dbVersion: dbVersion,
+                    key,
+                    newVersion,
+                    dbVersion,
                     synchronization: options.synchronization ||
                         "WRITETHROUGH",
                     force: typeof options.force === "boolean" ?
@@ -800,27 +800,27 @@ export class PutPDU extends PDU {
  * Response for the PUT request following the kinetic protocol.
  * @param {number} ackSequence - monotically increasing number for each request
  *                               in a TCP connection
- * @param {number} response - response code (SUCCESS, FAIL)
- * @param {Buffer} errorMessage - detailed error message.
+ * @param {number} code - response code (SUCCESS, FAIL)
+ * @param {Buffer} errorMessageArg - detailed error message.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class PutResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessageArg) {
+    constructor(ackSequence, code, errorMessageArg) {
         super();
 
-        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
 
         this.setMessage({
             header: {
                 messageType: "PUT_RESPONSE",
-                ackSequence: ackSequence,
+                ackSequence,
             },
             body: {
                 keyValue: { },
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;
@@ -851,14 +851,14 @@ export class GetPDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "GET",
-                connectionID: connectionID,
-                sequence: sequence,
+                connectionID,
+                sequence,
                 clusterVersion: Number.isInteger(options.clusterVersion) ?
                     options.clusterVersion : 0,
             },
             body: {
                 keyValue: {
-                    key: key,
+                    key,
                     metadataOnly: typeof options.metadataOnly === "boolean" ?
                                     options.metadataOnly : null,
                 },
@@ -873,18 +873,18 @@ export class GetPDU extends PDU {
  * @param {number} ackSequence - monotically increasing number for each request
  *                               in a TCP connection
  * @param {number} response - response code (SUCCESS, FAIL)
- * @param {Buffer} errorMessage - Detailed error message.
+ * @param {Buffer} errorMessageArg - Detailed error message.
  * @param {Buffer} key - key of the item to gotten item.
  * @param {number} chunkSize - size of the got chunk.
  * @param {Buffer} dbVersion - The version of the item in the database.
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class GetResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessageArg, keyArg,
+    constructor(ackSequence, code, errorMessageArg, keyArg,
                 chunkSize, dbVersionArg) {
         super();
 
-        const errorMessage = validateBufferOrStringArgument(errorMessageArg);
+        const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
         const key = validateBufferOrStringArgument(keyArg);
         const dbVersion = validateBufferArgument(dbVersionArg);
 
@@ -892,17 +892,17 @@ export class GetResponsePDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "GET_RESPONSE",
-                ackSequence: ackSequence,
+                ackSequence,
             },
             body: {
                 keyValue: {
-                    key: key,
-                    dbVersion: dbVersion,
+                    key,
+                    dbVersion,
                 },
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;
@@ -941,15 +941,15 @@ export class DeletePDU extends PDU {
         this.setMessage({
             header: {
                 messageType: "DELETE",
-                connectionID: connectionID,
-                sequence: sequence,
+                connectionID,
+                sequence,
                 clusterVersion: Number.isInteger(options.clusterVersion) ?
                     options.clusterVersion : 0,
             },
             body: {
                 keyValue: {
-                    key: key,
-                    dbVersion: dbVersion,
+                    key,
+                    dbVersion,
                     synchronization: options.synchronization ||
                         "WRITETHROUGH",
                     force: typeof options.force === "boolean" ?
@@ -970,23 +970,23 @@ export class DeletePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 export class DeleteResponsePDU extends PDU {
-    constructor(ackSequence, response, errorMessage) {
+    constructor(ackSequence, code, detailedMessage) {
         super();
 
-        if (!Buffer.isBuffer(errorMessage))
+        if (!Buffer.isBuffer(detailedMessage))
             throw new Error("the error message is not a buffer");
 
         this.setMessage({
             header: {
                 messageType: "DELETE_RESPONSE",
-                ackSequence: ackSequence,
+                ackSequence,
             },
             body: {
                 keyValue: { },
             },
             status: {
-                code: response,
-                detailedMessage: errorMessage,
+                code,
+                detailedMessage,
             },
         });
         return this;


### PR DESCRIPTION
- Clean the double quotes for objects to be more unified with the project
- Use double quotes for string to unify the lib

This PR follow the PR https://github.com/scality/kineticlib/pull/19
