### PR TITLE
PDU: Accept numeric dbVersion and newVersion

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -506,14 +506,16 @@ export function streamToPDU(s, callback) {
     });
 }
 
-function validateBufferArgument(arg, allowUndefined = false) {
-    if (Buffer.isBuffer(arg))
+function validateVersionArgument(arg) {
+    if (Buffer.isBuffer(arg)) {
         return arg;
+    } else if (typeof arg === "number") {
+        const buf = new Buffer(4);
+        buf.writeInt32BE(arg);
+        return buf;
+    }
 
-    if (allowUndefined && arg === undefined)
-        return arg;
-
-    throw propError("badArg", "argument is not a buffer");
+    throw propError("badArg", "Version is neither a buffer nor a number");
 }
 
 function validateBufferOrStringArgument(arg) {
@@ -522,7 +524,7 @@ function validateBufferOrStringArgument(arg) {
     else if (typeof arg === "string")
         return new Buffer(arg);
 
-    throw propError("badArg", "argument is neither a buffer nor a string");
+    throw propError("badArg", "Argument is neither a buffer nor a string");
 }
 
 /**
@@ -791,9 +793,9 @@ export class PutPDU extends PDU {
 
         const key = validateBufferOrStringArgument(keyArg);
         if (options.dbVersion)
-            dbVersion = validateBufferArgument(options.dbVersion);
+            dbVersion = validateVersionArgument(options.dbVersion);
         if (options.newVersion)
-            newVersion = validateBufferArgument(options.newVersion);
+            newVersion = validateVersionArgument(options.newVersion);
 
         const connectionID = (new Date).getTime();
         this._chunkSize = chunkSize;
@@ -910,7 +912,7 @@ export class GetResponsePDU extends PDU {
 
         const errorMessage = validateBufferOrStringArgument(errorMessageArg);
         const key = validateBufferOrStringArgument(keyArg);
-        const dbVersion = validateBufferArgument(dbVersionArg);
+        const dbVersion = validateVersionArgument(dbVersionArg);
 
         this._chunkSize = chunkSize;
         this.setMessage({
@@ -959,7 +961,7 @@ export class DeletePDU extends PDU {
 
         const key = validateBufferOrStringArgument(keyArg);
         if (options.dbVersion)
-            dbVersion = validateBufferArgument(options.dbVersion);
+            dbVersion = validateVersionArgument(options.dbVersion);
 
         const connectionID = (new Date).getTime();
         this.setMessage({

--- a/tests/unit/kinetic.js
+++ b/tests/unit/kinetic.js
@@ -913,16 +913,23 @@ describe('kinetic.PutPDU()', () => {
         }
     });
 
-    it('should not accept non-buffer dbVersion', (done) => {
-        const options = {
-            dbVersion: '2',
-            newVersion: new Buffer('3'),
-        };
-
+    it('should accept numeric dbVersion', (done) => {
         try {
-            const k = new kinetic.PutPDU(1, "string", 12, options);
+            const k = new kinetic.PutPDU(1, "string", 12, { dbVersion: 345 });
             k;
-            done(new Error("constructor accepted string-typed key"));
+            done();
+        } catch (e) {
+            done(e);
+        }
+    });
+
+    it('should not accept badly-typed dbVersion', (done) => {
+        try {
+            const k = new kinetic.PutPDU(1, "string", 12,
+                                         { dbVersion: { a: 1 },
+                                           newVersion: new Buffer('3') });
+            k;
+            done(new Error("constructor accepted object-typed key"));
         } catch (e) {
             if (e.badArg)
                 done();
@@ -931,14 +938,21 @@ describe('kinetic.PutPDU()', () => {
         }
     });
 
-    it('should not accept non-buffer newVersion', (done) => {
-        const options = {
-            dbVersion: new Buffer('2'),
-            newVersion: '3',
-        };
-
+    it('should accept numeric newVersion', (done) => {
         try {
-            const k = new kinetic.PutPDU(1, 'string', 12, options);
+            const k = new kinetic.PutPDU(1, "string", 12, { newVersion: 346 });
+            k;
+            done();
+        } catch (e) {
+            done(e);
+        }
+    });
+
+    it('should not accept non-buffer newVersion', (done) => {
+        try {
+            const k = new kinetic.PutPDU(1, 'string', 12,
+                                         { dbVersion: new Buffer('2'),
+                                           newVersion: { s: 'abc' } });
             k;
             done(new Error("constructor accepted string-typed key"));
         } catch (e) {
@@ -999,15 +1013,22 @@ describe('kinetic.DeletePDU()', () => {
         }
     });
 
-    it('should not accept non-buffer dbVersion', (done) => {
-        const options = {
-            dbVersion: '3',
-        };
-
+    it('should accept numeric dbVersion', (done) => {
         try {
-            const k = new kinetic.DeletePDU(1, "string", options);
+            const k = new kinetic.DeletePDU(1, "string", { dbVersion: 345 });
             k;
-            done(new Error("constructor accepted string-typed key"));
+            done();
+        } catch (e) {
+            done(e);
+        }
+    });
+
+    it('should not accept badly-typed dbVersion', (done) => {
+        try {
+            const k = new kinetic.DeletePDU(1, "string",
+                                            { dbVersion: { a: 1 } });
+            k;
+            done(new Error("constructor accepted object-typed key"));
         } catch (e) {
             if (e.badArg)
                 done();


### PR DESCRIPTION
Currently the only accepted type for dbVersion and newVersion are buffers. This
leads to client code going very long, example:

``` js
const k = new kinetic.PutPDU(124, 1989, "key", chunk.length,
                             { dbVersion: new Buffer(0),
                               newVersion: new Buffer('1') });
```

Outside of the project, clients will be very likely to use number for versions
(and inside IronMan, we are not even going to use versions.)

Fixes: #23
