### PR TITLE
FT: Implement getLogObject

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -373,16 +373,15 @@ export class PDU extends stream.Readable {
     }
 
     /**
-     * Gets the logs message.
+     * Gets the logs object.
      *
-     * @returns {Buffer} - Logs message, or `undefined` if missing.
+     * @returns {Object} - Logs, or `undefined` if missing.
      */
-    getGetLogMessage() {
-        if (this._message.body.getLog === null
-                || this._message.body.getLog.messages === null)
+    getLogObject() {
+        if (this._message.body.getLog === null)
             return undefined;
 
-        return this.getSlice(this._message.body.getLog.messages);
+        return this._message.body.getLog;
     }
 
     /**

--- a/tests/unit/kinetic.js
+++ b/tests/unit/kinetic.js
@@ -61,7 +61,7 @@ describe('kinetic.PDU decoding()', () => {
             assert.deepEqual(pdu.getDbVersion(), undefined);
             assert.deepEqual(pdu.getNewVersion(), undefined);
             assert.deepEqual(pdu._message.status.code, kinetic.errors.SUCCESS);
-            assert.deepEqual(typeof pdu._message.body.getLog, 'object');
+            assert.deepEqual(typeof pdu.getLogObject(), 'object');
         }, done);
     });
 
@@ -339,8 +339,7 @@ describe('kinetic.PDU decoding()', () => {
             assert.deepEqual(pdu.getChunkSize(), 0);
             assert.deepEqual(pdu.getMessageType(), kinetic.ops.GETLOG_RESPONSE);
             assert.deepEqual(pdu.getSequence(), 4);
-            assert.deepEqual(pdu._message.body.getLog.types,
-                [0, 1, 2, 4, 5, 6]);
+            assert.deepEqual(pdu.getLogObject().types, [0, 1, 2, 4, 5, 6]);
         }, done);
     });
 


### PR DESCRIPTION
- Implement getLogObject that return the logs
- Add the function to the corresponding tests

Question : 
What do you think about removing : 

``` js
    /**
     * Gets the logs message.
     *
     * @returns {Buffer} - Logs message, or `undefined` if missing.
     */
    getGetLogMessage() {
        if (this._message.body.getLog === null
                || this._message.body.getLog.messages === null)
            return undefined;

        return this.getSlice(this._message.body.getLog.messages);
    }
```

I think this one is not really needed anymore if we add the getLogObject().
