### PR TITLE
Tests: Add a scenario with 50 transactions in a single socket

### DIFF
--- a/tests/unit/kinetic.js
+++ b/tests/unit/kinetic.js
@@ -577,6 +577,41 @@ describe('kinetic.streamToPDU()', () => {
             otherEnd.write(input);
         });
     });
+
+    it('should accept 50 transactions in the same TCP session', (done) => {
+        const input = new Buffer(
+            "\x46\x00\x00\x00\x3e\x00\x00\x00\x1c\x20\x01\x2a\x18\x08\x01\x12" +
+            "\x14\x7d\x41\xc3\xd7\x37\xb9\x69\x82\xef\xb5\x2d\x7b\xc3\x9f\x47" +
+            "\x35\x82\x92\x29\x6d\x3a\x20\x0a\x0d\x08\x00\x18\xdb\x9e\xcc\xc0" +
+            "\x8d\x2a\x20\x00\x38\x04\x12\x0f\x0a\x0d\x12\x01\x31\x1a\x04qwer" +
+            "\x22\x00\x48\x01ON DIT BONJOUR TOUT LE MONDE", "ascii");
+
+        getNewSocket((socket, otherEnd) => {
+            function newTransaction(n) {
+                kinetic.streamToPDU(socket, (err, pdu) => {
+                    if (err)
+                        return done(err);
+
+                    posixRead(socket, pdu.getChunkSize(), (err, chunk) => {
+                        if (err)
+                            return done(err);
+
+                        assert.deepStrictEqual(
+                            chunk, new Buffer("ON DIT BONJOUR TOUT LE MONDE"));
+
+                        if (n > 0)
+                            newTransaction(n - 1);
+                        else
+                            done();
+                    });
+                });
+
+                otherEnd.write(input);
+            }
+
+            newTransaction(50);
+        });
+    });
 });
 
 describe('kinetic.PDU encoding()', () => {


### PR DESCRIPTION
This commit adds a test to make sure kineticlib's streamToPDU() can handle multiple transactions in the same TCP session.
