### PR TITLE
FIX- Add a condition in getErrorMessage

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -404,7 +404,9 @@ class PDU extends stream.Readable {
      * @returns {Buffer} - Detailed error message.
      */
     getErrorMessage() {
-        return this.getSlice(this._command.status.detailedMessage);
+        return this._command.status.detailedMessage ?
+            this.getSlice(this._command.status.detailedMessage) :
+            this._command.status.statusMessage;
     }
 
     /**


### PR DESCRIPTION
#### FIX- Add a condition in getErrorMessage

Before this method were just searching in detailed message,
now it also searching in statusMessage

---
#48 needs to be merged before this one.

Only the second commit needs to be reviewed.
