### PR TITLE
FIX - clusterVersion

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -15,6 +15,8 @@ const HEADER_VERSION_OFFSET = 0;
 const HEADER_PBUFSZ_OFFSET = 1;
 const HEADER_CHUNKSZ_OFFSET = 5;
 
+let clusterVersion = 0;
+
 /**
  * Gets the actual version of the kinetic protocol.
  * @returns {number} - the current version of the kinetic
@@ -488,6 +490,9 @@ class PDU extends stream.Readable {
         if (this._protobuf.authType === 1 && !this.checkHmacIntegrity(
                     this.getSlice(this._protobuf.hmacAuth.hmac)))
             throw propError("hmacFail", "HMAC does not match");
+        if (this.getMessageType() === null) {
+            clusterVersion = this.getClusterVersion();
+        }
     }
 }
 
@@ -567,12 +572,13 @@ class InitPDU extends PDU {
         this._authType = 'UNSOLICITEDSTATUS';
 
         const connectionID = (new Date).getTime();
+        clusterVersion = Number.isInteger(options.clusterVersion) ?
+                  options.clusterVersion : 0;
 
         this.setCommand({
             header: {
                 connectionID,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 getLog,
@@ -608,8 +614,7 @@ class GetLogPDU extends PDU {
                 messageType: "GETLOG",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 getLog: {
@@ -663,10 +668,9 @@ class GetLogResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class FlushPDU extends PDU {
-    constructor(sequence, optionsA) {
+    constructor(sequence) {
         super();
 
-        const options = optionsA || {};
         const connectionID = (new Date).getTime();
 
         this.setCommand({
@@ -674,8 +678,7 @@ class FlushPDU extends PDU {
                 messageType: "FLUSHALLDATA",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
             },
@@ -782,10 +785,9 @@ class SetupResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class NoOpPDU extends PDU {
-    constructor(sequence, optionsA) {
+    constructor(sequence) {
         super();
 
-        const options = optionsA || {};
         const connectionID = (new Date).getTime();
 
         this.setCommand({
@@ -793,8 +795,7 @@ class NoOpPDU extends PDU {
                 messageType: "NOOP",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
             },
@@ -871,8 +872,7 @@ class PutPDU extends PDU {
                 messageType: "PUT",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 keyValue: {
@@ -948,8 +948,7 @@ class GetPDU extends PDU {
                 messageType: "GET",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 keyValue: {
@@ -1039,8 +1038,7 @@ class DeletePDU extends PDU {
                 messageType: "DELETE",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 keyValue: {

--- a/tests/unit/kinetic.js
+++ b/tests/unit/kinetic.js
@@ -759,19 +759,19 @@ describe('kinetic.PDU encoding()', () => {
     });
 
     it('should write valid NOOP', (done) => {
-        const result = new kinetic.NoOpPDU(123, {clusterVersion: 9876798})
+        const result = new kinetic.NoOpPDU(123)
             .read();
 
         const expected = Buffer.from(
-            "\x46\x00\x00\x00\x32\x00\x00\x00\x00\x20\x01\x2a\x18\x08\x01\x12" +
+            "\x46\x00\x00\x00\x2f\x00\x00\x00\x00\x20\x01\x2a\x18\x08\x01\x12" +
             "\x14\xde\x57\x30\x36\x5a\x4a\x6f\xb7\x88\x02\x0b\xc4\x38\x0f\x76" +
-            "\xd9\xf1\xae\x57\x3b\x3a\x14\x0a\x10\x08\xbe\xea\xda\x04\x18\x82" +
-            "\xf9\xdb\x8f\x8d\x2a\x20\x7b\x38\x1e\x12\x00", "ascii");
+            "\xd9\xf1\xae\x57\x3b\x3a\x11\x0a\x0d\x08\x00\x18\xf7\xe6\x8d\xf9" +
+            "\xf9\x2a\x20\x7b\x38\x1e\x12\x00", "ascii");
 
-        // Ignore the timestamp bytes (17 -> 37 & 47 -> 51)
+        // Ignore the timestamp bytes (17 -> 37 & 44 -> 47)
         assert(result.slice(0, 17).equals(expected.slice(0, 17)));
-        assert(result.slice(37, 47).equals(expected.slice(37, 47)));
-        assert(result.slice(52).equals(expected.slice(52)));
+        assert(result.slice(37, 44).equals(expected.slice(37, 44)));
+        assert(result.slice(47).equals(expected.slice(47)));
 
         done();
     });
@@ -1434,10 +1434,12 @@ describe('kinetic LONG number getters ', () => {
 
     it('should decode LONG clusterVersion to number max:9223372036854776000',
         (done) => {
-            const rawData = new kinetic.NoOpPDU(1,
-                {clusterVersion: 9223372036854776000}).read();
+            const pdu = new kinetic.InitPDU(
+                {}, { clusterVersion: 9223372036854776000 });
+            const rawData = new kinetic.NoOpPDU(1).read();
             const k = new kinetic.PDU(rawData);
 
+            assert.strictEqual(pdu.getClusterVersion(), 9223372036854776000);
             assert.strictEqual(k.getClusterVersion(), 9223372036854776000);
 
             done();


### PR DESCRIPTION
Before we always had to send manually the clusterVersion, that is
something not needed because we have to use the InitPDU clusterVersion

Update associated tests
