### PR TITLE
FIX(kinetic): connectionID/clusterVersion/TAG

### DIFF
--- a/lib/kinetic.js
+++ b/lib/kinetic.js
@@ -422,6 +422,15 @@ class PDU extends stream.Readable {
     }
 
     /**
+     * Gets the pdu connection ID
+     *
+     * @returns {Number} - the connection ID.
+     */
+    getConnectionId() {
+        return this._command.header.connectionID.toNumber();
+    }
+
+    /**
      * Test the HMAC integrity between the actual instance and the given HMAC
      * @param {Buffer} hmac - the non instance hmac to compare
      * @returns {Boolean} - whether HMAC matches or not
@@ -558,20 +567,17 @@ class InitPDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class GetLogPDU extends PDU {
-    constructor(sequence, optionsA) {
+    constructor(sequence, connectionID, clusterVersion, optionsA) {
         super();
 
         const options = optionsA || {};
-
-        const connectionID = (new Date).getTime();
 
         this.setCommand({
             header: {
                 messageType: "GETLOG",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 getLog: {
@@ -620,24 +626,21 @@ class GetLogResponsePDU extends PDU {
  * Flush all data request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection.
+ * @param {number} connectionID - the connection ID received from the InitPDU
  * @param {Object} options - optional :
  *                  {number} [options.clusterVersion = 0] - the cluster version
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class FlushPDU extends PDU {
-    constructor(sequence, optionsA) {
+    constructor(sequence, connectionID, clusterVersion) {
         super();
-
-        const options = optionsA || {};
-        const connectionID = (new Date).getTime();
 
         this.setCommand({
             header: {
                 messageType: "FLUSHALLDATA",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
             },
@@ -685,10 +688,9 @@ class FlushResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class SetClusterVersionPDU extends PDU {
-    constructor(sequence, newClusterVersion, clusterVersion) {
+    constructor(sequence, connectionID, newClusterVersion, clusterVersion) {
         super();
 
-        const connectionID = (new Date).getTime();
 
         this.setCommand({
             header: {
@@ -739,24 +741,21 @@ class SetupResponsePDU extends PDU {
  * NOOP request following the kinetic protocol.
  * @param {number} sequence - monotonically increasing number for each
  *                                request in a TCP connection
+ * @param {number} connectionID - the connection ID received from the InitPDU
  * @param {Object} options - optional :
  *                  {number} [options.clusterVersion = 0] - the cluster version
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class NoOpPDU extends PDU {
-    constructor(sequence, optionsA) {
+    constructor(sequence, connectionID, clusterVersion) {
         super();
-
-        const options = optionsA || {};
-        const connectionID = (new Date).getTime();
 
         this.setCommand({
             header: {
                 messageType: "NOOP",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
             },
@@ -812,7 +811,8 @@ class NoOpResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class PutPDU extends PDU {
-    constructor(sequence, keyArg, chunkSize, optionsA) {
+    constructor(sequence, connectionID, clusterVersion, keyArg, chunkSize,
+                tagArg, optionsA) {
         super();
 
         const options = optionsA || {};
@@ -821,20 +821,19 @@ class PutPDU extends PDU {
         let newVersion = null;
 
         const key = validateBufferOrStringArgument(keyArg);
+        const tag = validateVersionArgument(tagArg);
         if (options.dbVersion)
             dbVersion = validateVersionArgument(options.dbVersion);
         if (options.newVersion)
             newVersion = validateVersionArgument(options.newVersion);
 
-        const connectionID = (new Date).getTime();
         this._chunkSize = chunkSize;
         this.setCommand({
             header: {
                 messageType: "PUT",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 keyValue: {
@@ -842,9 +841,11 @@ class PutPDU extends PDU {
                     newVersion,
                     dbVersion,
                     synchronization: options.synchronization ||
-                        "WRITETHROUGH",
+                        "WRITEBACK",
                     force: typeof options.force === "boolean" ?
-                             options.force : null,
+                        options.force : null,
+                    tag,
+                    algorithm: "SHA1",
                 },
             },
         });
@@ -898,20 +899,18 @@ class PutResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class GetPDU extends PDU {
-    constructor(sequence, keyArg, optionsA) {
+    constructor(sequence, connectionID, clusterVersion, keyArg, optionsA) {
         super();
 
         const options = optionsA || {};
         const key = validateBufferOrStringArgument(keyArg);
-        const connectionID = (new Date).getTime();
 
         this.setCommand({
             header: {
                 messageType: "GET",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 keyValue: {
@@ -938,12 +937,13 @@ class GetPDU extends PDU {
  */
 class GetResponsePDU extends PDU {
     constructor(ackSequence, code, errorMessageArg, keyArg,
-                chunkSize, dbVersionArg) {
+                chunkSize, dbVersionArg, tagArg) {
         super();
 
         const detailedMessage = validateBufferOrStringArgument(errorMessageArg);
         const key = validateBufferOrStringArgument(keyArg);
         const dbVersion = validateVersionArgument(dbVersionArg);
+        const tag = validateVersionArgument(tagArg);
 
         this._chunkSize = chunkSize;
         this.setCommand({
@@ -955,6 +955,8 @@ class GetResponsePDU extends PDU {
                 keyValue: {
                     key,
                     dbVersion,
+                    tag,
+                    algorithm: "SHA1",
                 },
             },
             status: {
@@ -985,7 +987,7 @@ class GetResponsePDU extends PDU {
  * @returns {Kinetic} - message structure following the kinetic protocol
  */
 class DeletePDU extends PDU {
-    constructor(sequence, keyArg, optionsA) {
+    constructor(sequence, connectionID, clusterVersion, keyArg, optionsA) {
         super();
 
         const options = optionsA || {};
@@ -995,21 +997,19 @@ class DeletePDU extends PDU {
         if (options.dbVersion)
             dbVersion = validateVersionArgument(options.dbVersion);
 
-        const connectionID = (new Date).getTime();
         this.setCommand({
             header: {
                 messageType: "DELETE",
                 connectionID,
                 sequence,
-                clusterVersion: Number.isInteger(options.clusterVersion) ?
-                    options.clusterVersion : 0,
+                clusterVersion,
             },
             body: {
                 keyValue: {
                     key,
                     dbVersion,
                     synchronization: options.synchronization ||
-                        "WRITETHROUGH",
+                        "WRITEBACK",
                     force: typeof options.force === "boolean" ?
                              options.force : null,
                 },


### PR DESCRIPTION
### connectionID/clusterVersion:

   Before we always compute new connectionID with a new Date(), that is
   something not needed because we have to use the InitPDU connectionID.
   It is the same for the clusterVersion.
   Now the library user have to had the connectionID and the
   clusterVersion to the new instances of PDU.

``` js
   const pdu = new kinetic.NoOpPDU(
       sequence, connectionID, clusterVersion)
```

---
### TAG:

   The tag is the integrity value for the data.
   This value should be computed by the client application by
   applying the hash algorithm specified below to the value(and only to
   the value). The algorithm used should be specified in the
   algorithm field. The Kinetic Device will not do any processing on
   this value.
